### PR TITLE
Linux 向けビルドでの permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   - push
   - pull_request
 
@@ -58,8 +58,10 @@ jobs:
         run: npm run build
       - name: Pack for Linux
         run: npm run pack:linux
+      - name: Tar files
+        run: tar -cvf "ZpDIC for Shaleian (Linux).tar" product/*.AppImage
       - name: Upload for Linux
         uses: actions/upload-artifact@v2
         with:
-          name: ZpDIC for Shaleian (Linux)
-          path: product/*.AppImage
+          name: "ZpDIC for Shaleian (Linux).tar"
+          path: "ZpDIC for Shaleian (Linux).tar"


### PR DESCRIPTION
`upload-artifact@v2` は zip する際にファイルの executable permission を喪失してしまうらしい．
予め tar ball にしておくことで，それを回避するようにしました．
(`ZpDIC for Shaleian (Linux).tar.zip` となって tar と zip で二重になってしまうのが若干気持ち悪いかもしれないけれど， `tar -xzvf "ZpDIC for Shaleian (Linux).tar.zip"` で一気に展開できるので別に問題ないと思います)

参考: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files